### PR TITLE
Add ability to replace vanilla strings

### DIFF
--- a/CustomLocalization/Core.cs
+++ b/CustomLocalization/Core.cs
@@ -593,6 +593,14 @@ namespace CustomTranslation {
         text = Core.localizationCache[text];
         return;
       }
+      // Straight vanilla string replacement: "BULWARK" -> "Foobar"
+      string upperText = text.ToUpper(CultureInfo.InvariantCulture);
+      if (Core.stringsTable.ContainsKey(upperText)) {
+        Log.M?.LogWrite("Plain replacement: " + text + "\n");
+        text = Core.getLocalizationString(upperText);
+        Log.M?.LogWrite("-> " + text + "\n");
+      }
+      // Mod string replacement: "__BULWARK__: __BULWARKBONUS__" -> "Foobar: Baz"
       MatchCollection matches = Core.locRegEx.Matches(text);
       //Log.M?.LogWrite(text + "\n");
       string original = text;
@@ -618,6 +626,14 @@ namespace CustomTranslation {
         text = Core.localizationCache[text];
         return;
       }
+      // Straight vanilla string replacement: "BULWARK" -> "Foobar"
+      string upperText = text.ToUpper(CultureInfo.InvariantCulture);
+      if (Core.stringsTable.ContainsKey(upperText)) {
+        Log.M?.LogWrite("Plain replacement: " + text + "\n");
+        text = Core.getLocalizationString(upperText,culture);
+        Log.M?.LogWrite("-> " + text + "\n");
+      }
+      // Mod string replacement: "__BULWARK__: __BULWARKBONUS__" -> "Foobar: Baz"
       MatchCollection matches = Core.locRegEx.Matches(text);
       //Log.M?.LogWrite(text + "\n");
       string original = text;


### PR DESCRIPTION
Over the years, several mods have patched vanilla methods for the sole purpose of overriding hardcoded strings.

CustomLocalization is already hooked into the right places to do this generically. This PR allows Localization.json definitions of the form

```
[
	{
		"FileName": "",
		"Name": "20% damage reduction against ranged attacks to the front and side.\nStacks with COVER.\nGUARDED is countered by any Melee attack, and ignored by BREACHING SHOT.",
		"Localization": {
			"CULTURE_EN_US": "FOOBAR BAZ BALLz"
		}
	},
	{
		"FileName": "",
		"Name": "GUARDED",
		"Localization": {
			"CULTURE_EN_US": "FOOBAR BAZ BALLz"
		}
	}
]
```

to override vanilla values.